### PR TITLE
Add limit to URLs shown at history table

### DIFF
--- a/ui/src/History.css
+++ b/ui/src/History.css
@@ -1,32 +1,25 @@
+#history-table .request abbr {
+  display: inline-block;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  vertical-align: bottom;
+}
+
 @media screen and (min-width: 781px) {
   #history-table .request abbr {
     max-width: 600px;
-    display: inline-block;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-    vertical-align: bottom;
   }
 }
 
 @media screen and (max-width: 780px) {
   #history-table .request abbr {
     max-width: 400px;
-    display: inline-block;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-    vertical-align: bottom;
   }
 }
 
 @media screen and (max-width: 500px) {
   #history-table .request abbr {
     max-width: 380px;
-    display: inline-block;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-    vertical-align: bottom;
   }
 }

--- a/ui/src/History.css
+++ b/ui/src/History.css
@@ -1,0 +1,32 @@
+@media screen and (min-width: 781px) {
+  #history-table .request abbr {
+    max-width: 600px;
+    display: inline-block;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    vertical-align: bottom;
+  }
+}
+
+@media screen and (max-width: 780px) {
+  #history-table .request abbr {
+    max-width: 400px;
+    display: inline-block;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    vertical-align: bottom;
+  }
+}
+
+@media screen and (max-width: 500px) {
+  #history-table .request abbr {
+    max-width: 380px;
+    display: inline-block;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    vertical-align: bottom;
+  }
+}

--- a/ui/src/History.js
+++ b/ui/src/History.js
@@ -1,5 +1,6 @@
-import { IconHeader, LiveFilter, useTitle } from './util'
-import { useState } from 'react';
+import {IconHeader, LiveFilter, useTitle} from './util'
+import {useState} from 'react';
+import "./History.css"
 
 function convertSize(bytes) {
   if (bytes < 1024) {

--- a/ui/src/History.js
+++ b/ui/src/History.js
@@ -61,8 +61,8 @@ function Request(props) {
 export default function History() {
   useTitle("History")
   const [history, setHistory] = useState(null);
-  return <div className="card history table-responsive">
-    <LiveFilter endpoint="/history" onUpdate={setHistory} minDelay={2000} />
+  return <div id="history-table" className="card history table-responsive">
+    <LiveFilter endpoint="/history" onUpdate={setHistory} minDelay={2000}/>
     {history != null && <table className='table text-start table-sm'>
       <thead>
         <tr className="text-uppercase text-muted">


### PR DESCRIPTION
Adds a limit to requested URL shown in the history table, this fixes the issue when these strings are to long.

Isn't perfect, but it does the job ;)

![image](https://github.com/nfx/slrp/assets/35047123/761c441f-9562-476f-8fe0-15ee1c15ea4c)
