### PR TITLE
Added `probe.enable_http_rescue` experimental feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ Proxy pool maintenance.
 * `evict_threshold_failures` - number of failures within the last `evict_span_minutes` to evict proxy from the pool.
 * `evict_threshold_reanimations` - number of any proxy sleeps ever to evict proxy from the pool.
 
+## probe
+
+Proxy probing component.
+
+* `enable_http_rescue` - experimental feature to enable rescuing HTTP proxies, that were presented as SOCKS5 or HTTPS. Detected based on protocol probe heuristics. Defaults to false.
+
 ## mitm
 
 HTTP proxy frontend.

--- a/pmux/proxy.go
+++ b/pmux/proxy.go
@@ -58,6 +58,18 @@ func (p Proxy) IP() net.IP {
 	return net.IPv4(byte(a), byte(b), byte(c), byte(d))
 }
 
+func (p Proxy) AsHttp() Proxy {
+	ip := uint64(p>>32) << 32
+	port := uint64(p.Port()) << 16
+	return Proxy(ip + port + uint64(HTTP))
+}
+
+func (p Proxy) AsHttps() Proxy {
+	ip := uint64(p>>32) << 32
+	port := uint64(p.Port()) << 16
+	return Proxy(ip + port + uint64(HTTPS))
+}
+
 func (p Proxy) Address() string {
 	ip := p >> 32
 	a := ip >> 24 & 0xff

--- a/pmux/proxy_test.go
+++ b/pmux/proxy_test.go
@@ -20,6 +20,12 @@ func TestNewProxy(t *testing.T) {
 	}
 }
 
+func TestSocksToHttp(t *testing.T) {
+	p := NewProxy("1.2.4.5:8731", "socks4")
+	assert.Equal(t, "http://1.2.4.5:8731", p.AsHttp().String())
+	assert.Equal(t, "https://1.2.4.5:8731", p.AsHttps().String())
+}
+
 func TestProxyIP(t *testing.T) {
 	assert.Equal(t, net.IPv4(1, 2, 3, 4), HttpProxy("1.2.3.4:56789").IP())
 }


### PR DESCRIPTION
Try rescuing HTTP proxies if one of the following errors bubble up:

- "server gave HTTP response to HTTPS client",
- "first record does not look like a TLS handshake",
- "unknown socks4 server response 84", // HTTP/1.1 from SOCK4 lib we're using
- "unexpected protocol version 72",    // H is 72 in ASCII (https://ascii.cl/ is handy)