### PR TITLE
Fix `curl` call in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ SLRP - rotating open proxy multiplexer
 
 # Usage
 
-Download service, start it up, wait couple of minutes for the pool to pick up. Now run `curl -D - -x http://127.0.0.1:8090 -k http://httpbin.org/get` couple of times and see different origins and user agent headers.
+Download service, start it up, wait couple of minutes for the pool to pick up. Now run `curl --proxy-insecure -D - -x http://127.0.0.1:8090 -k http://httpbin.org/get` couple of times and see different origins and user agent headers.
 
 # Concepts
 


### PR DESCRIPTION
Since slrp v0.3.0 uses HTTPS proxy (nfx/slrp#149) with self-signed certificate instead of HTTP proxy, it is necessary to use `curl --proxy-insecure` instead of `curl` to connect via this proxy without getting error "curl: (60) SSL certificate problem: self signed certificate".

See https://curl.se/docs/sslcerts.html#https-proxy

Resolves nfx/slrp#153